### PR TITLE
TASK-3 Remove Private Questions From API Response

### DIFF
--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -4,7 +4,8 @@ module Api
   module V1
     class QuestionsController < ApplicationController
       def index
-        questions = Question.all
+        # Only retrieve public questions
+        questions = Question.where(private: false)
         render status: :ok, json: questions, each_serializer: QuestionSerializer
       end
     end

--- a/spec/requests/api/v1/questions_spec.rb
+++ b/spec/requests/api/v1/questions_spec.rb
@@ -12,10 +12,10 @@ describe '/api/v1/questions', type: :request do
     end
 
     let(:question_1) do
-      FactoryBot.create(:question, user_id: user_1.id)
+      FactoryBot.create(:question, user_id: user_1.id, private: false)
     end
     let(:question_2) do
-      FactoryBot.create(:question, user_id: user_2.id)
+      FactoryBot.create(:question, user_id: user_2.id, private: false)
     end
     let(:private_question) do
       FactoryBot.create(:question, user_id: user_2.id, private: true)

--- a/spec/requests/api/v1/questions_spec.rb
+++ b/spec/requests/api/v1/questions_spec.rb
@@ -17,6 +17,9 @@ describe '/api/v1/questions', type: :request do
     let(:question_2) do
       FactoryBot.create(:question, user_id: user_2.id)
     end
+    let(:private_question) do
+      FactoryBot.create(:question, user_id: user_2.id, private: true)
+    end
 
     let(:answer_1) do
       FactoryBot.create(:answer, user_id: user_1.id, question_id: question_2.id)
@@ -32,6 +35,7 @@ describe '/api/v1/questions', type: :request do
     before do
       answer_1
       answer_2
+      private_question
     end
 
     context 'with no query params passed' do
@@ -87,7 +91,7 @@ describe '/api/v1/questions', type: :request do
         expect(response).to have_http_status(200)
       end
 
-      it 'successfully retrieves questions' do
+      it 'successfully retrieves public questions' do
         subject
         response_body = JSON.parse(response.body)
         expect(response_body).to match_array(expected_response)


### PR DESCRIPTION
Added Functionality
---
- [x] Remove `private` questions from `/api/v1/questions` response.

Functional Testing
---
<details close>
<summary>Successful Requests Screenshots</summary>
<img width="907" alt="Screen Shot 2020-10-13 at 10 42 56 AM" src="https://user-images.githubusercontent.com/57879598/95883854-00a85800-0d41-11eb-8eb3-131d46121bfe.png">
</details>

<details close>
<summary>Debugger Screenshots</summary>
<img width="891" alt="Screen Shot 2020-10-13 at 10 38 39 AM" src="https://user-images.githubusercontent.com/57879598/95883894-0ef67400-0d41-11eb-8635-a5e38b059ef4.png">
<img width="890" alt="Screen Shot 2020-10-13 at 10 39 46 AM" src="https://user-images.githubusercontent.com/57879598/95883921-17e74580-0d41-11eb-9e76-bc690a206293.png">
</details>

Unit Testing
---
* Added RSpec specs.