### PR TITLE
TASK-9 Add Basic Querying for Questions

### DIFF
--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -10,7 +10,7 @@ module Api
         public_questions = Question.where(private: false)
 
         result_questions = if search_params[:title].present?
-                             # Search for public questions that contain the partial 'title' string
+                             # Search for public questions that contain the partial title param string
                              public_questions.search(search_params[:title])
                            else
                              # Only return public questions

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -6,9 +6,25 @@ module Api
       before_action :authenticate!
 
       def index
-        # Only retrieve public questions
-        questions = Question.where(private: false)
+        questions = if search_params[:title].present?
+          # Search for public questions that contain the partial 'title' string
+          Question.where(private: false).search(search_params[:title])
+        else
+          # Only retrieve public questions
+          Question.where(private: false)
+        end
+
         render status: :ok, json: questions, each_serializer: QuestionSerializer
+      end
+
+      private
+
+      #
+      # Helper methods
+      #
+
+      def search_params
+        params.permit(:title)
       end
     end
   end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -6,15 +6,18 @@ module Api
       before_action :authenticate!
 
       def index
-        questions = if search_params[:title].present?
+        # Retrieve all public questions
+        public_questions = Question.where(private: false)
+
+        result_questions = if search_params[:title].present?
           # Search for public questions that contain the partial 'title' string
-          Question.where(private: false).search(search_params[:title])
+          public_questions.search(search_params[:title])
         else
-          # Only retrieve public questions
-          Question.where(private: false)
+          # Only return public questions
+          public_questions
         end
 
-        render status: :ok, json: questions, each_serializer: QuestionSerializer
+        render status: :ok, json: result_questions, each_serializer: QuestionSerializer
       end
 
       private

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -10,12 +10,12 @@ module Api
         public_questions = Question.where(private: false)
 
         result_questions = if search_params[:title].present?
-          # Search for public questions that contain the partial 'title' string
-          public_questions.search(search_params[:title])
-        else
-          # Only return public questions
-          public_questions
-        end
+                             # Search for public questions that contain the partial 'title' string
+                             public_questions.search(search_params[:title])
+                           else
+                             # Only return public questions
+                             public_questions
+                           end
 
         render status: :ok, json: result_questions, each_serializer: QuestionSerializer
       end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,6 +6,6 @@ class Question < ApplicationRecord
 
   # Searches for a question title that contains the partial title string
   scope :search, lambda { |title|
-    where("title LIKE ?", "%#{title}%")
+    where('title LIKE ?', "%#{title}%")
   }
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,4 +3,9 @@
 class Question < ApplicationRecord
   has_many :answers, dependent: :destroy
   belongs_to :user
+
+  # Searches for a question title that contains the partial title string
+  scope :search, lambda { |title|
+    where("title LIKE ?", "%#{title}%")
+  }
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -7,4 +7,41 @@ RSpec.describe Question, type: :model do
     it { should have_many(:answers).dependent(:destroy) }
     it { should belong_to(:user) }
   end
+
+  describe '.search' do
+    subject { Question.search(title_query_match) }
+
+    context 'with questions that do and do not contain the title param' do
+      let(:user_1) do
+        FactoryBot.create(:user)
+      end
+
+      let(:title_query_match) { 'soup' }
+      let(:question_1_title) { "Is cereal #{title_query_match}?" }
+      let(:question_2_title) { 'Do you like bread?' }
+      let(:question_3_title) { "Do you like #{title_query_match} with bread?" }
+      let(:question_1) do
+        FactoryBot.create(:question, user_id: user_1.id, title: question_1_title)
+      end
+      let(:question_2) do
+        FactoryBot.create(:question, user_id: user_1.id, title: question_2_title)
+      end
+      let(:question_3) do
+        FactoryBot.create(:question, user_id: user_1.id, title: question_3_title)
+      end
+
+      before do
+        question_1
+        question_2
+      end
+
+      it "includes questions that contain the title param" do
+        expect(subject).to include(question_1, question_3)
+      end
+
+      it "does not include questions that do not contain the title param" do
+        expect(subject).not_to include(question_2)
+      end
+    end
+  end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe Question, type: :model do
         question_2
       end
 
-      it "includes questions that contain the title param" do
+      it 'includes questions that contain the title param' do
         expect(subject).to include(question_1, question_3)
       end
 
-      it "does not include questions that do not contain the title param" do
+      it 'does not include questions that do not contain the title param' do
         expect(subject).not_to include(question_2)
       end
     end

--- a/spec/requests/api/v1/questions_spec.rb
+++ b/spec/requests/api/v1/questions_spec.rb
@@ -45,7 +45,7 @@ describe '/api/v1/questions', type: :request do
       FactoryBot.create(:answer, user_id: user_2.id, question_id: question_1.id)
     end
 
-    let(:request_query_params) {{}}
+    let(:request_query_params) { {} }
     subject do
       get '/api/v1/questions', params: request_query_params, headers: headers
     end
@@ -120,7 +120,7 @@ describe '/api/v1/questions', type: :request do
       end
 
       context 'with title in the query params' do
-        let(:request_query_params) {{ title: title_query_match }}
+        let(:request_query_params) { { title: title_query_match } }
         let(:expected_response) do
           [
             expected_question_1

--- a/spec/requests/api/v1/questions_spec.rb
+++ b/spec/requests/api/v1/questions_spec.rb
@@ -24,14 +24,18 @@ describe '/api/v1/questions', type: :request do
       FactoryBot.create(:user)
     end
 
+    let(:title_query_match) { 'soup' }
+    let(:question_1_title) { "Is cereal #{title_query_match}?" }
+    let(:question_2_title) { 'Do you like bread?' }
+    let(:private_question_title) { "Is cereal not #{title_query_match}?" }
     let(:question_1) do
-      FactoryBot.create(:question, user_id: user_1.id, private: false)
+      FactoryBot.create(:question, user_id: user_1.id, title: question_1_title, private: false)
     end
     let(:question_2) do
-      FactoryBot.create(:question, user_id: user_2.id, private: false)
+      FactoryBot.create(:question, user_id: user_2.id, title: question_2_title, private: false)
     end
     let(:private_question) do
-      FactoryBot.create(:question, user_id: user_2.id, private: true)
+      FactoryBot.create(:question, user_id: user_2.id, title: private_question_title, private: true)
     end
 
     let(:answer_1) do
@@ -41,8 +45,9 @@ describe '/api/v1/questions', type: :request do
       FactoryBot.create(:answer, user_id: user_2.id, question_id: question_1.id)
     end
 
+    let(:request_query_params) {{}}
     subject do
-      get '/api/v1/questions', headers: headers
+      get '/api/v1/questions', params: request_query_params, headers: headers
     end
 
     before do
@@ -112,6 +117,21 @@ describe '/api/v1/questions', type: :request do
 
       it 'increments the tenant request count' do
         expect { subject }.to change { tenant_1.reload.request_count }.by(1)
+      end
+
+      context 'with title in the query params' do
+        let(:request_query_params) {{ title: title_query_match }}
+        let(:expected_response) do
+          [
+            expected_question_1
+          ]
+        end
+
+        it 'successfully retrieves public questions that contain the title param' do
+          subject
+          response_body = JSON.parse(response.body)
+          expect(response_body).to match_array(expected_response)
+        end
       end
     end
 


### PR DESCRIPTION
Added Functionality
---
- [x] Added the `title` query param to the `/api/v1/questions` endpoint for retrieving all public questions that contain the `title`.

Functional Testing
---
<details close>
<summary>Successful Requests Screenshots</summary>
<img width="830" alt="Screen Shot 2020-10-15 at 10 13 05 PM" src="https://user-images.githubusercontent.com/57879598/96208693-b935ed80-0f33-11eb-95ff-cbb901cef976.png">
<img width="908" alt="Screen Shot 2020-10-15 at 10 16 01 PM" src="https://user-images.githubusercontent.com/57879598/96208886-1336b300-0f34-11eb-9116-847f5916eee7.png">
</details>


Unit Testing
---
* Added RSpec specs.